### PR TITLE
Implement data_binding caching in node

### DIFF
--- a/lib/hiera/backend/data_mapper_backend.rb
+++ b/lib/hiera/backend/data_mapper_backend.rb
@@ -1,0 +1,18 @@
+class Hiera
+  module Backend
+    class Data_mapper_backend
+
+      def lookup(key, scope, order_override, resolution_type)
+        unless data_bindings = scope['node_data_bindings']
+          raise(
+            Exception,
+            "expected variable: #{node_data_bindings} to be set from node terminus"
+          )
+        end
+        data_bindings[key]
+      end
+
+    end
+
+  end
+end

--- a/lib/puppet/face/scenario.rb
+++ b/lib/puppet/face/scenario.rb
@@ -65,6 +65,10 @@ Puppet::Face.define(:scenario, '0.0.1') do
 
     arguments 'key'
 
+    option '--interpolate_hiera_data' do
+      summary 'Tells hiera to interpolate its data'
+    end
+
     option '--certname_for_facts CERTNAME' do
       summary 'The certname to use to retrieve facts used to compile hierarchies'
       default_to { Puppet[:certname] }


### PR DESCRIPTION
This commit updates the node terminus such that it
stores its current data_bindings somewhere where the
custom hiera backend can find them.

This is being implemented for a few reasons:
- precompiling all hiera data is way faster than data bindings
- precompiling all hiera data is a useful debugging tool
- if we have debugging tools that perform precompiles, they should
  use the same logic that is used by the Puppet master.
