### PR TITLE
Regex matching for node names

### DIFF
--- a/lib/puppet/bodepd/scenario_helper.rb
+++ b/lib/puppet/bodepd/scenario_helper.rb
@@ -350,14 +350,28 @@ module Puppet
         end
         role_mappings = YAML.load_file(role_mapper)
         split_name = name.split('.')
-        split_name.size.times do |x|
-          cur_name = split_name[0..(split_name.size-x-1)].join('.')
-          role = role_mappings[cur_name]
-          if role
-            Puppet.debug("Found role from role mappings: #{role}")
-            return role
+
+        regexes = Hash.new
+        role_mappings.each do | role_match, role|
+          # Strip the regex of any wrapping slashes that might exist
+          role_match = role_match.sub(/^\//, '').sub(/\/$/, '')
+          begin
+            regexes[(Regexp.new(role_match))] = role
+          rescue => detail
+            raise ArgumentError, "Invalid regex in role_mappings '#{role_match}': #{detail}", detail.backtrace
           end
         end
+
+        split_name.size.times do |x|
+          cur_name = split_name[0..(split_name.size-x-1)].join('.')
+          regexes.each do | regex, role|
+            if ( cur_name =~ regex)
+              Puppet.debug("Found role from role mappings: #{role}")
+              return role
+            end
+          end
+        end
+
         Puppet.debug("Did not find role mapping for #{name}")
         return nil
       end

--- a/spec/unit/puppet/bodepd/scenario_helper_spec.rb
+++ b/spec/unit/puppet/bodepd/scenario_helper_spec.rb
@@ -76,7 +76,7 @@ key: value
 overridable_key: default_value
 array:
   - one
-hash
+hash:
   one: two
 EOT
     )


### PR DESCRIPTION
This patch adds naive support for regexes in hostnames in the
same format as the traditional puppet node terminus.
