### PR TITLE
raise StandardError, not Exception for errors

### DIFF
--- a/lib/hiera/backend/data_mapper_backend.rb
+++ b/lib/hiera/backend/data_mapper_backend.rb
@@ -11,7 +11,7 @@ class Hiera
       def lookup(key, scope, order_override, resolution_type)
         unless data_bindings = scope['node_data_bindings']
           raise(
-            Exception,
+            StandardError,
             "expected variable: #{node_data_bindings} to be set from node terminus"
           )
         end

--- a/lib/puppet/bodepd/scenario_helper.rb
+++ b/lib/puppet/bodepd/scenario_helper.rb
@@ -253,6 +253,10 @@ module Puppet
         else
           raise(StandardError, 'config.yaml must exist')
         end
+        local_config_file = get_data_file(data_dir, 'config.local.yaml')
+        if File.exists?(local_config_file)
+          global_config.merge!(YAML.load_file(local_config_file))
+        end
         if ! global_config || ! global_config['scenario']
           raise(StandardError, 'scenario must be defined in config.yaml')
         end

--- a/lib/puppet/bodepd/scenario_helper.rb
+++ b/lib/puppet/bodepd/scenario_helper.rb
@@ -185,7 +185,7 @@ module Puppet
               # I am not sure how forgiving I should be here...
               #
               if class_list.include?(get_namespace(k))
-                raise(Exception, "data mapping #{v} not found. Failing b/c it is required for class #{get_namespace(k)}")
+                raise(StandardError, "data mapping #{v} not found. Failing b/c it is required for class #{get_namespace(k)}")
               end
               Puppet.warning("data_mapping key: #{k} maps to #{v} which is not found in hiera data. This may not be an issue, b/c the class #{get_namespace(k)} is not included.")
               lookedup_data[k] = nil
@@ -251,10 +251,10 @@ module Puppet
         if File.exists?(global_config_file)
           global_config = YAML.load_file(global_config_file)
         else
-          raise(Exception, 'config.yaml must exist')
+          raise(StandardError, 'config.yaml must exist')
         end
         if ! global_config || ! global_config['scenario']
-          raise(Exception, 'scenario must be defined in config.yaml')
+          raise(StandardError, 'scenario must be defined in config.yaml')
         end
         Puppet.info("Found scenario: #{global_config['scenario']} in #{global_config_file}")
         Puppet.info("Using scenario to help determine hiera globals")
@@ -285,7 +285,7 @@ module Puppet
           end
         end
         unless hierarchy.include?("%{scenario}")
-          raise(Exception, "Having a hierachy named scenario is required")
+          raise(StandardError, "Having a hierachy named scenario is required")
         end
         data = get_keys_per_dir(scope, 'scenarios', hierarchy) do |k,v,data|
           if data == {}
@@ -321,7 +321,7 @@ module Puppet
           group_names.reduce([]) do |result, name|
             group_file = get_data_file(group_dir, "#{name}.yaml")
             unless File.exists?(group_file)
-              raise(Exception, "Group file #{group_file} does not exist")
+              raise(StandardError, "Group file #{group_file} does not exist")
             end
             class_group = YAML.load_file(group_file)
             result + process_classes(class_group, scope)
@@ -346,7 +346,7 @@ module Puppet
       def get_role(name)
         role_mapper = get_data_file(data_dir, 'role_mappings.yaml')
         unless File.exists?(role_mapper)
-          raise(Exception, "Role mapping file: #{role_mapper} should exist")
+          raise(StandardError, "Role mapping file: #{role_mapper} should exist")
         end
         role_mappings = YAML.load_file(role_mapper)
         split_name = name.split('.')
@@ -486,7 +486,7 @@ module Puppet
       def interpolate_string(string, scope)
         if string.is_a?(String)
           string.gsub(/%\{([^\}]*)\}/) do
-            scope[$1] || raise(Exception, "Interpolation for #{$1} failed")
+            scope[$1] || raise(StandardError, "Interpolation for #{$1} failed")
           end
         else
           string


### PR DESCRIPTION
Replaced all instances of raising Exception with raising StandardError,
so that puppet can properly catch the errors and report them.

This fixes the error reporting around a missing scenario:

```
# puppet agent -t
Error: Could not run Puppet configuration client: scenario must be defined in config.yaml
Error: Could not run: can't convert Puppet::Util::Log into Integer
```

After changing this to StandardError the Puppet::Util::Log error is no
longer reported and you get the following instead:

```
# puppet agent -t
Error: Failed to apply catalog: scenario must be defined in config.yaml
```
